### PR TITLE
refactor: removed duplicate logic

### DIFF
--- a/app/infrastructure/queue_consumer.py
+++ b/app/infrastructure/queue_consumer.py
@@ -102,13 +102,6 @@ class QueueConsumer:
         try:
 
             result = await self.queue.dequeue(queue_name, job_types=job_types)
-            if result:
-                await self._process_job(queue_name, result)
-            else:
-                # No jobs available, wait before checking again
-                await asyncio.sleep(settings.QUEUE_POLLING_INTERVAL_SECONDS or 5)
-                return None
-
             return result
 
         except Exception as e:


### PR DESCRIPTION
Description:

In the `async def _worker(self, worker_id: str):` function, we are calling this logic twice successively:
```
 if job:
                    await self._process_job(worker_id, job)
                else:
                    # No jobs available, wait before polling again
                    await asyncio.sleep(self.poll_interval)

```
Once in the `job = await self._dequeue_job("testing", ["load_locust", "load_tests"])` method that `_worker` calls and then directly afterwards we call the same logic again.