### PR TITLE
DEV 31 QnA system does not use the desired LLM methodology, its currently simple, using repo_reference_system, use the proper methodology via vectorized data

### DIFF
--- a/app/infrastructure/qna/qna_generator.py
+++ b/app/infrastructure/qna/qna_generator.py
@@ -442,6 +442,11 @@ def sanitize_custom_questions_shape(questions: QuestionsIn) -> Optional[List[Que
 # --------------------------------------------
 # Public API (pure function returning QnA data)
 # --------------------------------------------
+
+def get_default_questions():
+    return DEFAULT_QUESTIONS
+
+
 async def generate_project_qna(
         *,
         id_for_repo: str,

--- a/app/services/load_test.py
+++ b/app/services/load_test.py
@@ -13,7 +13,7 @@ from app.schemas.load_test import LoadTestRequest, LoadTestResult, LoadTestStatu
 from together import Together
 from app.config import settings, supabase_queue
 from app.utils.auth import UserClaims
-from app.utils.encryption import FernetEncryptionHelper
+from app.utils.encryption import get_encryption_helper
 from devdox_ai_locust import HybridLocustGenerator
 from devdox_ai_locust.schemas.processing_result import SwaggerProcessingRequest
 from devdox_ai_locust.utils.swagger_utils import get_api_schema
@@ -187,7 +187,9 @@ class LoadTestService:
                         "token_id": repo_info.token_id
                     }
                 )
-
+            
+            fernet_encryption_helper = get_encryption_helper()
+            
 
             job_payload = LoadLocustPayload(
                 repo_id = str(repo_info.repo_id),
@@ -197,7 +199,7 @@ class LoadTestService:
                 git_token = str(token_info.id),
                 git_provider = token_info.git_hosting,
                 auth_token=(
-                    FernetEncryptionHelper().encrypt(user_claims.git_token)
+                    fernet_encryption_helper.encrypt(user_claims.git_token)
                     if (
                             token_info.git_hosting
                             and user_claims.git_provider

--- a/app/services/load_test_processor.py
+++ b/app/services/load_test_processor.py
@@ -14,7 +14,7 @@ from app.infrastructure.queue_job_tracker.job_trace_metadata import JobTraceMeta
 from app.infrastructure.queue_job_tracker.job_tracker import JobLevels, JobTracker
 from app.schemas.load_test import LoadTestRequest, LoadTestConfig, RepositoryValidationError
 from app.services.api_test_generator import APITestGenerator
-from app.utils.encryption import FernetEncryptionHelper
+from app.utils.encryption import get_encryption_helper
 from devdox_ai_git.repo_fetcher import RepoFetcher
 from models_src.repositories.git_label import TortoiseGitLabelStore as GitLabelRepository
 from models_src.repositories.repo import TortoiseRepoStore as RepoRepository
@@ -141,12 +141,14 @@ def extract_files_for_commit(result: List[dict], repo_root: Path) -> Dict[str, s
     return files_for_commit
 
 def  get_token(token_db:str,encryption_salt:str, git_provider_label:str,git_provider:str, auth_token:str|None) -> str:
+    fernet_encryption_helper = get_encryption_helper()
+    
     if auth_token and git_provider == git_provider_label:
-        return  FernetEncryptionHelper().decrypt(auth_token)
+        return  fernet_encryption_helper.decrypt(auth_token)
     else:
-        return FernetEncryptionHelper().decrypt_for_user(
+        return fernet_encryption_helper.decrypt_for_user(
                     token_db,
-                    salt_b64=FernetEncryptionHelper().decrypt(encryption_salt)
+                    salt_b64=fernet_encryption_helper.decrypt(encryption_salt)
                 )
 
 def get_repo_info(git_provider, created_repo):

--- a/app/services/qna.py
+++ b/app/services/qna.py
@@ -1,24 +1,33 @@
 import logging
-from typing import Annotated, List, Optional
+from typing import Annotated, Any, List, Optional
 
+from encryption_src.fernet.service import FernetEncryptionHelper
 from fastapi import Depends
+from models_src.repositories.code_chunks import TortoiseCodeChunksStore
 from models_src.repositories.repo import TortoiseRepoStore
+from models_src.repositories.user import TortoiseUserStore
 from pydantic import BaseModel, EmailStr
 from together import AsyncTogether
 
 from app.config import settings
-from app.infrastructure.mailing_service import Template
+from app.infrastructure.mailing_service import EmailDispatcher, Template
 from app.infrastructure.mailing_service.container import get_email_dispatcher
 from app.infrastructure.mailing_service.models.context_shapes import Meta, Project, QAPair, QAReport
 from app.exceptions.custom_exceptions import QnAGenerationFailed, RepoAnalysisNotCompleted, ResourceNotFound
 from app.exceptions.exception_constants import REPO_ANALYSIS_FAILED, REPO_ANALYSIS_NOT_REQUESTED, REPOSITORY_NOT_FOUND
 from app.infrastructure.qna.formatters.qna_formatter_text import format_qna_text
-from app.infrastructure.qna.qna_generator import generate_project_qna
+from app.infrastructure.qna.qna_generator import generate_project_qna, get_default_questions
 from app.infrastructure.qna.qna_models import ProjectQnAPackage
 from app.schemas.repo import RepoStatus
 from app.utils.auth import UserClaims
+from app.utils.encryption import get_encryption_helper
+
+from cohere import AsyncClientV2 as CohereAsyncClientV2
 
 logger = logging.getLogger(__name__)
+
+BERT_EMBEDDING_MODEL_1 = "togethercomputer/m2-bert-80M-32k-retrieval"
+TOTAL_K = 10  # context budget
 
 class GetAnswersResponse(BaseModel):
 	qna_pkg: ProjectQnAPackage | None = None
@@ -27,16 +36,38 @@ class GetAnswersResponse(BaseModel):
 
 class QnAService:
 	
-	def __init__(self, repo_store: TortoiseRepoStore):
+	def __init__(
+			self,
+			repo_store: TortoiseRepoStore,
+			email_dispatcher: EmailDispatcher,
+			code_chunks_store: TortoiseCodeChunksStore,
+			user_store: TortoiseUserStore,
+			encryption_service: FernetEncryptionHelper,
+	):
 		
 		self.repo_store = repo_store
+		self.email_dispatcher = email_dispatcher
+		self.code_chunks_store = code_chunks_store
+		self.user_store = user_store
+		self.encryption_service = encryption_service
 	
 	@classmethod
 	def with_dependency(
 			cls,
 			repo_store: Annotated[TortoiseRepoStore, Depends()],
+			email_dispatcher: Annotated[EmailDispatcher, Depends(get_email_dispatcher)],
+			code_chunks_store: Annotated[TortoiseCodeChunksStore, Depends()],
+			user_store: Annotated[TortoiseUserStore, Depends()],
+			encryption_service: Annotated[FernetEncryptionHelper, Depends(get_encryption_helper)],
+			
 	) -> "QnAService":
-		return cls(repo_store)
+		return cls(
+			repo_store=repo_store,
+			email_dispatcher=email_dispatcher,
+			code_chunks_store=code_chunks_store,
+			user_store=user_store,
+			encryption_service=encryption_service
+		)
 	
 	# ---------- public API ----------
 	
@@ -56,6 +87,38 @@ class QnAService:
 		return GetAnswersResponse(user_email=user_claims.email, qna_pkg=qna_pkg, format_qna_text=formatted_qna)
 	
 	# ---------- private helpers ----------
+	
+	async def _generate_qna(self, repo) -> ProjectQnAPackage:
+		
+		client = AsyncTogether(api_key=settings.TOGETHER_API_KEY)
+		
+		questions = [q for _, q in get_default_questions()]
+		
+		# Build a grounded context from vectors (+ README).
+		context_blob = await self._build_context_from_chunks(
+			together=client,
+			user_id=repo.user_id,
+			repo_id=str(repo.id),
+			questions=questions,
+			top_k=TOTAL_K,
+			truncate_chars=12000,
+		)
+		
+		# Fallback: if nothing retrieved, use repo_system_reference
+		effective_context = (context_blob or (repo.repo_system_reference or "")).strip()
+		
+		qna_pkg = await generate_project_qna(
+			id_for_repo=str(repo.id),
+			project_name=repo.repo_name,
+			repo_url=repo.html_url,
+			repo_system_reference=effective_context,  # <- grounded context now
+			together_client=client,
+			# (OPTIONAL) pass explicit questions here if you want to override defaults
+			# questions=[("goal", "..."), ...],
+		)
+		if not qna_pkg:
+			raise QnAGenerationFailed()
+		return qna_pkg
 	
 	async def _find_repo_or_raise(self, user_id: str, alias: str):
 		repo = await self.repo_store.find_by_user_and_alias_name(
@@ -78,21 +141,6 @@ class QnAService:
 			
 		raise RepoAnalysisNotCompleted()
 
-	
-	async def _generate_qna(self, repo) -> ProjectQnAPackage:
-		
-		client = AsyncTogether(api_key=settings.TOGETHER_API_KEY)
-		qna_pkg = await generate_project_qna(
-			id_for_repo=str(repo.id),
-			project_name=repo.repo_name,
-			repo_url=repo.html_url,
-			repo_system_reference=repo.repo_system_reference,
-			together_client=client,
-		)
-		if not qna_pkg:
-			raise QnAGenerationFailed()
-		return qna_pkg
-	
 	async def _send_summary_if_possible(self, user_email: Optional[EmailStr], qna_pkg: ProjectQnAPackage) -> None:
 		if not user_email:
 			logger.info("Skipping QnA summary email: no user email on claims.")
@@ -102,8 +150,6 @@ class QnAService:
 		except Exception:
 			logger.error("QnA summary email send failed")
 			raise
-	
-	# ---------- existing mail senders (unchanged) ----------
 	
 	async def send_qna_summary_email(self, to_email: EmailStr, qna_pkg: ProjectQnAPackage):
 		project_context_part = Project(name=qna_pkg.project_name, repo_url=qna_pkg.repo_url)
@@ -122,10 +168,104 @@ class QnAService:
 		]
 		qa_report_context = QAReport(project=project_context_part, meta=meta_context_part, pairs=pairs_context_part)
 		
-		email_dispatcher = get_email_dispatcher()
-		await email_dispatcher.send_templated_html(
+		await self.email_dispatcher.send_templated_html(
 			to=[to_email],
 			template=Template.PROJECT_QNA_SUMMARY,
 			context=qa_report_context,
 			base_context_shape_config={"by_alias": True},
 		)
+	
+	async def _embed_questions(self, client: AsyncTogether, questions: list[str]) -> list[list[float]]:
+		resp = await client.embeddings.create(input=questions, model=BERT_EMBEDDING_MODEL_1)
+		vecs = [d.embedding for d in resp.data]
+		if not vecs:
+			raise RuntimeError("empty embeddings")
+		dim = len(vecs[0])
+		if any(len(v) != dim for v in vecs) or dim != settings.VECTOR_SIZE:
+			raise RuntimeError(f"Embedding dim mismatch: got {dim}, expected {settings.VECTOR_SIZE}")
+		return vecs
+	
+	def _decrypt(self, encrypted: str, user_salt_b64: str) -> str:
+		if not encrypted:
+			return ""
+		return self.encryption_service.decrypt_for_user(encrypted, user_salt_b64)
+	
+	async def _readme_blob(self, user_id: str, repo_id: str, salt_b64: str) -> str:
+		rows = await self.code_chunks_store.get_repo_file_chunks(user_id, repo_id, file_name="readme")
+		out = []
+		for r in rows or []:
+			ct = r.get("content")
+			if ct:
+				out.append(self._decrypt(ct, salt_b64))
+		return "\n".join(out).strip()
+	
+	async def _cohere_rerank_optional(self, query: str, docs: list[str], top_n: int) -> list[int]:
+		# Optional precise rerank if key present; otherwise keep original order
+		if not settings.COHERE_API_KEY:
+			return list(range(min(top_n, len(docs))))
+		co = CohereAsyncClientV2(api_key=settings.COHERE_API_KEY)
+		rr = await co.rerank(query=query, documents=docs, top_n=min(top_n, len(docs)), model="rerank-v3.5")
+		# return indexes into docs
+		return [getattr(x, "index", i) for i, x in enumerate(getattr(rr, "results", [])) if hasattr(x, "index")]
+	
+	async def _build_context_from_chunks(
+			self,
+			*,
+			together: AsyncTogether,
+			user_id: str,
+			repo_id: str,
+			questions: list[str],
+			top_k: int = TOTAL_K,
+			truncate_chars: int = 12000,
+	) -> str:
+		# 1) user + salt for decryption
+		user = await self.user_store.find_by_user_id(user_id)
+		if not user or not user.encryption_salt:
+			return ""  # fail safe
+		
+		salt_b64 = self.encryption_service.decrypt(user.encryption_salt)
+		
+		# 2) embed questions
+		q_vecs = await self._embed_questions(together, questions)
+		
+		# 3) vector search with fusion (SUM of per-question sims)
+		rows: list[dict[str, Any]] = await self.code_chunks_store.get_user_repo_chunks_multi(
+			user_id=user_id, repo_id=repo_id, query_embeddings=q_vecs,
+			emb_dim=settings.VECTOR_SIZE, limit=top_k
+		)
+		if not rows:
+			return await self._readme_blob(user_id, str(repo_id), salt_b64)
+		
+		# 4) decrypt and collect texts
+		texts, file_names = [], []
+		for r in rows:
+			enc = r.get("content") or ""
+			txt = self._decrypt(enc, salt_b64)
+			if txt:
+				texts.append(txt)
+				file_names.append(r.get("file_name") or "unknown")
+		
+		if not texts:
+			return await self._readme_blob(user_id, str(repo_id), salt_b64)
+		
+		# 5) optional fine rerank against a merged multi-question query
+		merged_query = " | ".join(questions)
+		try:
+			order = await self._cohere_rerank_optional(merged_query, texts, top_n=min(len(texts), top_k))
+			texts = [texts[i] for i in order]
+			file_names = [file_names[i] for i in order]
+		except Exception:
+			logging.exception("Rerank failed; using vector order")
+		
+		# 6) prepend README as primer (if exists)
+		readme = await self._readme_blob(user_id, str(repo_id), salt_b64)
+		parts = []
+		if readme:
+			parts.append("### FILE: README ###\n" + readme)
+		for fn, t in zip(file_names, texts):
+			parts.append(f"### FILE: {fn} ###\n{t}")
+		
+		blob = "\n\n".join(parts).strip()
+		if truncate_chars and len(blob) > truncate_chars:
+			blob = blob[:truncate_chars]
+		return blob

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
    "email_validator==2.2.0",
    "tembo-pgmq-python==0.10.0",
    #models
-   "devdox-ai-models @ git+https://github.com/montymobile1/devdox-ai-models.git@a34f8d1",
+   "devdox-ai-models @ git+https://github.com/montymobile1/devdox-ai-models.git@7e06188",
    # Encryption package
    "devdox-ai-encryption @ git+https://github.com/montymobile1/devdox-ai-encryption.git@4eefae1",
    "devdox-ai-git @ git+https://github.com/montymobile1/devdox-ai-git.git@24741e6",


### PR DESCRIPTION
refactor: Change QnA API from using `repo_system_reference`, which is simple, to using contents in code chunks

Description:
The current methodology uses a simple repo_system_reference which is then fed to an LLM, and asked to answer questions from the repo_system_reference, as per recommendation, this is not the desired methodology to follow, switch to using vectorized data, reranking rather than repo_system_reference, like in the ask questions API in devdox-ai-agent in the same project.

Steps Taken:
I added the proper functionality to perform reranking and question building alongside content collecting. Exactly similar to Ask Questions, the only difference of course being, this API answers only default questions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Q&A generation with default questions, richer packaged outputs, customizable parameters, and batch processing
  * Optional document reranking to improve relevance

* **Refactor**
  * Q&A service rebuilt to integrate additional data sources, grounded context construction, and dependency injection for email, storage, and encryption; improved error handling

* **Chore**
  * Load-test and processing flows updated to use a centralized encryption helper
<!-- end of auto-generated comment: release notes by coderabbit.ai -->